### PR TITLE
Change some textareas to custom input

### DIFF
--- a/src/components/CustomInputText.tsx
+++ b/src/components/CustomInputText.tsx
@@ -1,0 +1,28 @@
+import { VariantProps, cva } from 'class-variance-authority';
+import React, { ComponentProps } from 'react';
+import { twMerge } from 'tailwind-merge';
+
+const customInputTextStyles = cva(['hover:bg-secondary-hover, transition-colors'], {
+    variants: {
+        variant: {
+            default: ['border', 'border-gray-300', 'rounded-md'],
+        },
+        size: {
+            default: ['w-full', 'mt-1', 'p-2'],
+        },
+    },
+    defaultVariants: {
+        variant: 'default',
+        size: 'default',
+    },
+});
+
+type CustomInputTextProps = VariantProps<typeof customInputTextStyles> & ComponentProps<'input'>;
+
+const CustomInputText: React.FC<CustomInputTextProps> = ({ variant, size, className, ...props }) => {
+    return (
+        <input {...props} className={twMerge(customInputTextStyles({ variant, size }), className)} />
+    );
+};
+
+export default CustomInputText;

--- a/src/pages/CreateThreadPage.tsx
+++ b/src/pages/CreateThreadPage.tsx
@@ -10,6 +10,7 @@ import PageTitle from '../components/PageTitle';
 import CategoryDropDown from '../components/CategoryDropDown';
 import CustomTextArea from '../components/CustomTextArea';
 import CustomLabel from '../components/CustomLabel';
+import CustomInputText from '../components/CustomInputText';
 
 const CreateThreadPage: React.FC = () => {
   const [title, setTitle] = useState('');
@@ -39,12 +40,10 @@ const CreateThreadPage: React.FC = () => {
         {loading && !error && <p>Loading...</p>}
         <form onSubmit={handleCreateThread} className='space-y-4 w-full'>
           <CustomLabel variant='default'>Title:</CustomLabel>
-          <CustomTextArea
+          <CustomInputText
             variant='default'
-            size='default'
             value={title}
             onChange={(e) => setTitle(e.target.value)}
-            rows={1}
             style={{ resize: 'vertical' }}
           />
           <CustomLabel variant='default'>Category:</CustomLabel>

--- a/src/popups/LoginPopup.tsx
+++ b/src/popups/LoginPopup.tsx
@@ -5,7 +5,7 @@ import { login } from '../store/auth/authSlice';
 import CustomButton from '../components/CustomButton';
 import PageTitle from '../components/PageTitle';
 import CustomLabel from '../components/CustomLabel';
-import CustomTextArea from '../components/CustomTextArea';
+import CustomInputText from '../components/CustomInputText';
 
 interface LoginFormData {
     username: string;
@@ -26,7 +26,7 @@ const LoginPopup: React.FC<LoginPopupProps> = ({ onRequestClose, onToggleForm })
     const auth = useSelector((state: RootState) => state.auth);
     const { loading, loginError } = auth;
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setFormData({
             ...formData,
             [e.target.name]: e.target.value,
@@ -48,10 +48,8 @@ const LoginPopup: React.FC<LoginPopupProps> = ({ onRequestClose, onToggleForm })
             {loginError && <p className='text-secondary-alert'>{loginError}</p>}
             <form onSubmit={handleSubmit} className='space-y-4 w-full mb-5'>
                 <CustomLabel variant='default'>Username:</CustomLabel>
-                <CustomTextArea
+                <CustomInputText
                     variant='default'
-                    size='default'
-                    rows={1}
                     name="username"
                     value={formData.username}
                     onChange={handleChange}
@@ -59,10 +57,8 @@ const LoginPopup: React.FC<LoginPopupProps> = ({ onRequestClose, onToggleForm })
                 />
                 <br />
                 <CustomLabel variant='default'>Password:</CustomLabel>
-                <CustomTextArea
+                <CustomInputText
                     variant='default'
-                    size='default'
-                    rows={1}
                     name="password"
                     value={formData.password}
                     onChange={handleChange}

--- a/src/popups/SignupPopup.tsx
+++ b/src/popups/SignupPopup.tsx
@@ -5,7 +5,7 @@ import { signup } from '../store/auth/authSlice';
 import CustomButton from '../components/CustomButton';
 import PageTitle from '../components/PageTitle';
 import CustomLabel from '../components/CustomLabel';
-import CustomTextArea from '../components/CustomTextArea';
+import CustomInputText from '../components/CustomInputText';
 
 interface SignupPopupProps {
     onToggleForm: () => void;
@@ -25,7 +25,7 @@ const SignupPopup: React.FC<SignupPopupProps> = ({ onToggleForm }) => {
     const auth = useSelector((state: RootState) => state.auth);
     const { loading, signupError } = auth;
 
-    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
         setFormData({
             ...formData,
             [e.target.name]: e.target.value,
@@ -47,10 +47,8 @@ const SignupPopup: React.FC<SignupPopupProps> = ({ onToggleForm }) => {
             {signupError && <p className='text-secondary-alert'>{signupError}</p>}
             <form onSubmit={handleSubmit} className='space-y-4 w-full mb-5'>
                 <CustomLabel variant='default'>Username:</CustomLabel>
-                <CustomTextArea
+                <CustomInputText
                     variant='default'
-                    size='default'
-                    rows={1}
                     name="username"
                     value={formData.username}
                     onChange={handleChange}
@@ -58,10 +56,8 @@ const SignupPopup: React.FC<SignupPopupProps> = ({ onToggleForm }) => {
                 />
                 <br />
                 <CustomLabel variant='default'>Password:</CustomLabel>
-                <CustomTextArea
+                <CustomInputText
                     variant='default'
-                    size='default'
-                    rows={1}
                     name="password"
                     value={formData.password}
                     onChange={handleChange}

--- a/src/sections/UpdateThreadComponent.tsx
+++ b/src/sections/UpdateThreadComponent.tsx
@@ -6,6 +6,7 @@ import CustomButton from '../components/CustomButton'
 import CategoryDropDown from '../components/CategoryDropDown'
 import CustomLabel from '../components/CustomLabel'
 import CustomTextArea from '../components/CustomTextArea'
+import CustomInputText from '../components/CustomInputText'
 
 // TODO: Block out the save CustomButton if no changes have been made
 
@@ -57,13 +58,10 @@ const UpdateThreadComponent: React.FC<UpdateThreadComponentProps> = ({ setIsEdit
             {thread && (
                 <form onSubmit={handleSubmit} className='flex flex-col justify-between mb-2'>
                     <CustomLabel variant='default'>Title:</CustomLabel>
-                    <CustomTextArea
+                    <CustomInputText
                         variant='default'
-                        size='default'
                         value={formData.title}
                         onChange={handleChange}
-                        rows={1}
-                        style={{ resize: 'vertical' }}
                     />
                     <CustomLabel variant='default'>Category:</CustomLabel>
                     <div className="relative inline-block text-left">


### PR DESCRIPTION
This fixes the problem where certain 1-line input areas are treated as textareas, caused by previous commit of changing all inputs and textareas to customtextarea